### PR TITLE
Voice nodes

### DIFF
--- a/Source/EIKVoiceChat/Functions/EVIK_Functions.cpp
+++ b/Source/EIKVoiceChat/Functions/EVIK_Functions.cpp
@@ -2,15 +2,16 @@
 
 
 #include "EVIK_Functions.h"
-#include "Runtime\Engine/Classes/GameFramework/PlayerController.h"
 #include "Interfaces/IHttpResponse.h"
 
 
-bool UEVIK_Functions::InitializeEOSVoiceChat(APlayerController* PlayerController)
+bool UEVIK_Functions::InitializeEOSVoiceChat(const UObject* WorldContextObject)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -22,11 +23,13 @@ bool UEVIK_Functions::InitializeEOSVoiceChat(APlayerController* PlayerController
 	return false;
 }
 
-void UEVIK_Functions::ConnectVoiceChat(APlayerController* PlayerController, const FEIKResultDelegate& Result)
+void UEVIK_Functions::ConnectVoiceChat(const UObject* WorldContextObject, const FEIKResultDelegate& Result)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -51,11 +54,13 @@ void UEVIK_Functions::ConnectVoiceChat(APlayerController* PlayerController, cons
 	}
 }
 
-void UEVIK_Functions::LoginEOSVoiceChat(APlayerController* PlayerController, FString PlayerName, const FEIKResultDelegate& Result)
+void UEVIK_Functions::LoginEOSVoiceChat(const UObject* WorldContextObject, FString PlayerName, const FEIKResultDelegate& Result)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -87,12 +92,14 @@ void UEVIK_Functions::LoginEOSVoiceChat(APlayerController* PlayerController, FSt
 	}
 }
 
-void UEVIK_Functions::LogoutEOSVoiceChat(APlayerController* PlayerController, FString PlayerName,
+void UEVIK_Functions::LogoutEOSVoiceChat(const UObject* WorldContextObject, FString PlayerName,
 	const FEIKResultDelegate& Result)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -117,11 +124,13 @@ void UEVIK_Functions::LogoutEOSVoiceChat(APlayerController* PlayerController, FS
 	}
 }
 
-FString UEVIK_Functions::LoggedInUser(APlayerController* PlayerController)
+FString UEVIK_Functions::LoggedInUser(const UObject* WorldContextObject)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -141,7 +150,7 @@ FString UEVIK_Functions::LoggedInUser(APlayerController* PlayerController)
 #include "Misc/ConfigCacheIni.h"
 #include "Http.h"
 
-void UEVIK_Functions::EOSRoomToken(APlayerController* PlayerController, FString VoiceRoomName, FString PlayerName, FString ClientIP, const FEIKRoomTokenResultDelegate& Result)
+void UEVIK_Functions::EOSRoomToken(FString VoiceRoomName, FString PlayerName, FString ClientIP, const FEIKRoomTokenResultDelegate& Result)
 {
     FString ProductId, SandboxId, DeploymentId, ClientId, ClientSecret, EncryptionKey;
     bool bEnabled;
@@ -278,11 +287,13 @@ void UEVIK_Functions::EOSRoomToken(APlayerController* PlayerController, FString 
     HttpRequest->ProcessRequest();
 }
 
-void UEVIK_Functions::JoinEOSRoom(APlayerController* PlayerController, FString VoiceRoomName, FString ChannelCredentialsJson,bool bEnableEcho, const FEIKResultDelegate& Result)
+void UEVIK_Functions::JoinEOSRoom(const UObject* WorldContextObject, FString VoiceRoomName, FString ChannelCredentialsJson,bool bEnableEcho, const FEIKResultDelegate& Result)
 {
-    if (PlayerController)
-    {
-        if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
+	{
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
         {
             UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
             if (LocalVoiceSubsystem)
@@ -331,12 +342,14 @@ void UEVIK_Functions::JoinEOSRoom(APlayerController* PlayerController, FString V
     }
 }
 
-void UEVIK_Functions::LeaveEOSRoom(APlayerController* PlayerController, FString VoiceRoomName,
+void UEVIK_Functions::LeaveEOSRoom(const UObject* WorldContextObject, FString VoiceRoomName,
 	const FEIKResultDelegate& Result)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -360,12 +373,14 @@ void UEVIK_Functions::LeaveEOSRoom(APlayerController* PlayerController, FString 
 	}
 }
 
-TArray<FString> UEVIK_Functions::GetPlayersInRoom(APlayerController* PlayerController, FString VoiceRoomName)
+TArray<FString> UEVIK_Functions::GetPlayersInRoom(const UObject* WorldContextObject, FString VoiceRoomName)
 {
 	TArray<FString> Local_PlayersInRoom;
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -380,12 +395,14 @@ TArray<FString> UEVIK_Functions::GetPlayersInRoom(APlayerController* PlayerContr
 	return Local_PlayersInRoom;
 }
 
-TArray<FString> UEVIK_Functions::GetAllRooms(APlayerController* PlayerController)
+TArray<FString> UEVIK_Functions::GetAllRooms(const UObject* WorldContextObject)
 {
 	TArray<FString> Local_PlayersJoinedRooms;
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -400,12 +417,14 @@ TArray<FString> UEVIK_Functions::GetAllRooms(APlayerController* PlayerController
 	return Local_PlayersJoinedRooms;
 }
 
-float UEVIK_Functions::GetPlayerVolume(const APlayerController* PlayerController, const FString& PlayerName)
+float UEVIK_Functions::GetPlayerVolume(const UObject* WorldContextObject, const FString& PlayerName)
 {
 	float Local_PlayerVolume = 0;
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -434,12 +453,14 @@ char* UEVIK_Functions::GetProductUserID(const FString& PlayerName)
 	return Local_ProductUserID;
 }
 
-bool UEVIK_Functions::SetPlayerVolume(const APlayerController* PlayerController, const FString& PlayerName,
+bool UEVIK_Functions::SetPlayerVolume(const UObject* WorldContextObject, const FString& PlayerName,
                                       float NewVolume)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -455,11 +476,13 @@ bool UEVIK_Functions::SetPlayerVolume(const APlayerController* PlayerController,
 	return false;
 }
 
-bool UEVIK_Functions::IsPlayerMuted(const APlayerController* PlayerController, const FString& PlayerName)
+bool UEVIK_Functions::IsPlayerMuted(const UObject* WorldContextObject, const FString& PlayerName)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -474,11 +497,13 @@ bool UEVIK_Functions::IsPlayerMuted(const APlayerController* PlayerController, c
 	return false;
 }
 
-bool UEVIK_Functions::SetPlayerMuted(const APlayerController* PlayerController, const FString& PlayerName, bool MutePlayer)
+bool UEVIK_Functions::SetPlayerMuted(const UObject* WorldContextObject, const FString& PlayerName, bool MutePlayer)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -494,11 +519,13 @@ bool UEVIK_Functions::SetPlayerMuted(const APlayerController* PlayerController, 
 	return false;
 }
 
-bool UEVIK_Functions::TransmitToAllRooms(const APlayerController* PlayerController)
+bool UEVIK_Functions::TransmitToAllRooms(const UObject* WorldContextObject)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -514,11 +541,13 @@ bool UEVIK_Functions::TransmitToAllRooms(const APlayerController* PlayerControll
 	return false;
 }
 
-bool UEVIK_Functions::TransmitToSelectedRoom(const APlayerController* PlayerController, FString RoomName)
+bool UEVIK_Functions::TransmitToSelectedRoom(const UObject* WorldContextObject, FString RoomName)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -534,11 +563,13 @@ bool UEVIK_Functions::TransmitToSelectedRoom(const APlayerController* PlayerCont
 	return false;
 }
 
-bool UEVIK_Functions::TransmitToNoRoom(const APlayerController* PlayerController)
+bool UEVIK_Functions::TransmitToNoRoom(const UObject* WorldContextObject)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -554,12 +585,14 @@ bool UEVIK_Functions::TransmitToNoRoom(const APlayerController* PlayerController
 	return false;
 }
 
-TArray<FDeviceEVIKSettings> UEVIK_Functions::GetInputMethods(const APlayerController* PlayerController)
+TArray<FDeviceEVIKSettings> UEVIK_Functions::GetInputMethods(const UObject* WorldContextObject)
 {
 	TArray<FDeviceEVIKSettings> Local_DeviceSettingArray;
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -582,12 +615,14 @@ TArray<FDeviceEVIKSettings> UEVIK_Functions::GetInputMethods(const APlayerContro
 	return Local_DeviceSettingArray;
 }
 
-TArray<FDeviceEVIKSettings> UEVIK_Functions::GetOutputMethods(const APlayerController* PlayerController)
+TArray<FDeviceEVIKSettings> UEVIK_Functions::GetOutputMethods(const UObject* WorldContextObject)
 {
 	TArray<FDeviceEVIKSettings> Local_DeviceSettingArray;
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -610,11 +645,13 @@ TArray<FDeviceEVIKSettings> UEVIK_Functions::GetOutputMethods(const APlayerContr
 	return Local_DeviceSettingArray;
 }
 
-bool UEVIK_Functions::SetOutputMethods(const APlayerController* PlayerController, FString MethodID)
+bool UEVIK_Functions::SetOutputMethods(const UObject* WorldContextObject, FString MethodID)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)
@@ -630,11 +667,13 @@ bool UEVIK_Functions::SetOutputMethods(const APlayerController* PlayerController
 	return false;
 }
 
-bool UEVIK_Functions::SetInputMethods(const APlayerController* PlayerController, FString MethodID)
+bool UEVIK_Functions::SetInputMethods(const UObject* WorldContextObject, FString MethodID)
 {
-	if (PlayerController)
+	UWorld* World = GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull);
+	
+	if (World)
 	{
-		if (const UGameInstance* GameInstance = PlayerController->GetGameInstance())
+		if (const UGameInstance* GameInstance = World->GetGameInstance())
 		{
 			UEIK_Voice_Subsystem* LocalVoiceSubsystem = GameInstance->GetSubsystem<UEIK_Voice_Subsystem>();
 			if (LocalVoiceSubsystem)

--- a/Source/EIKVoiceChat/Functions/EVIK_Functions.h
+++ b/Source/EIKVoiceChat/Functions/EVIK_Functions.h
@@ -20,91 +20,91 @@ class EIKVOICECHAT_API UEVIK_Functions : public UBlueprintFunctionLibrary
 
 public:
     // Initializes the EOS Voice Chat system.
-	UFUNCTION(BlueprintCallable, DisplayName="Intialize EOS Voice Chat", Category="EVIK")
-	static bool InitializeEOSVoiceChat(APlayerController* PlayerController);
+	UFUNCTION(BlueprintCallable, DisplayName="Intialize EOS Voice Chat", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+	static bool InitializeEOSVoiceChat(const UObject* WorldContextObject);
 
     // Connects the player to the EOS Voice Chat system.
-	UFUNCTION(BlueprintCallable, DisplayName="Connect to EOS Voice Chat", Category="EVIK", meta = (AutoCreateRefTerm = "Result"))
-	static void ConnectVoiceChat(APlayerController* PlayerController, const FEIKResultDelegate& Result);
+	UFUNCTION(BlueprintCallable, DisplayName="Connect to EOS Voice Chat", Category="EVIK", meta = (AutoCreateRefTerm = "Result", WorldContext="WorldContextObject"))
+	static void ConnectVoiceChat(const UObject* WorldContextObject, const FEIKResultDelegate& Result);
 
     // Logs the player into the EOS Voice Chat system.
-	UFUNCTION(BlueprintCallable, DisplayName="Login to EOS Voice Chat", Category="EVIK", meta = (AutoCreateRefTerm = "Result"))
-	static void LoginEOSVoiceChat(APlayerController* PlayerController, FString PlayerName, const FEIKResultDelegate& Result);
+	UFUNCTION(BlueprintCallable, DisplayName="Login to EOS Voice Chat", Category="EVIK", meta = (AutoCreateRefTerm = "Result", WorldContext="WorldContextObject"))
+	static void LoginEOSVoiceChat(const UObject* WorldContextObject, FString PlayerName, const FEIKResultDelegate& Result);
 
     // Logs the player out of the EOS Voice Chat system.
-	UFUNCTION(BlueprintCallable, DisplayName="Logout from EOS Voice Chat", Category="EVIK", meta = (AutoCreateRefTerm = "Result"))
-	static void LogoutEOSVoiceChat(APlayerController* PlayerController, FString PlayerName, const FEIKResultDelegate& Result);
+	UFUNCTION(BlueprintCallable, DisplayName="Logout from EOS Voice Chat", Category="EVIK", meta = (AutoCreateRefTerm = "Result", WorldContext="WorldContextObject"))
+	static void LogoutEOSVoiceChat(const UObject* WorldContextObject, FString PlayerName, const FEIKResultDelegate& Result);
 
     // Gets the logged-in user's name for the EOS Voice Chat system.
-	UFUNCTION(BlueprintPure, DisplayName="Get Logged in EOS Voice Chat User", Category="EVIK")
-	static FString LoggedInUser(APlayerController* PlayerController);
+	UFUNCTION(BlueprintPure, DisplayName="Get Logged in EOS Voice Chat User", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+	static FString LoggedInUser(const UObject* WorldContextObject);
 	
     // Requests a room token for the specified voice room.
-	UFUNCTION(BlueprintCallable, DisplayName="Get EOS Voice Room Token", Category="EVIK", meta = (AutoCreateRefTerm = "Result"))
-	static void EOSRoomToken(APlayerController* PlayerController, FString VoiceRoomName, FString PlayerName, FString ClientIP, const FEIKRoomTokenResultDelegate& Result);
+	UFUNCTION(BlueprintCallable, DisplayName="Get EOS Voice Room Token", Category="EVIK", meta = (AutoCreateRefTerm = "Result", WorldContext="WorldContextObject"))
+	static void EOSRoomToken(FString VoiceRoomName, FString PlayerName, FString ClientIP, const FEIKRoomTokenResultDelegate& Result);
 	
     // Joins the specified voice room.
-	UFUNCTION(BlueprintCallable, DisplayName="Join EOS Voice Room", Category="EVIK", meta = (AutoCreateRefTerm = "Result"))
-	static void JoinEOSRoom(APlayerController* PlayerController, FString VoiceRoomName, FString RoomData, bool bEnableEcho, const FEIKResultDelegate& Result);
+	UFUNCTION(BlueprintCallable, DisplayName="Join EOS Voice Room", Category="EVIK", meta = (AutoCreateRefTerm = "Result", WorldContext="WorldContextObject"))
+	static void JoinEOSRoom(const UObject* WorldContextObject, FString VoiceRoomName, FString RoomData, bool bEnableEcho, const FEIKResultDelegate& Result);
 
     // Leaves the specified voice room.
-	UFUNCTION(BlueprintCallable, DisplayName="Leave EOS Voice Room", Category="EVIK", meta = (AutoCreateRefTerm = "Result"))
-	static void LeaveEOSRoom(APlayerController* PlayerController, FString VoiceRoomName, const FEIKResultDelegate& Result);
+	UFUNCTION(BlueprintCallable, DisplayName="Leave EOS Voice Room", Category="EVIK", meta = (AutoCreateRefTerm = "Result", WorldContext="WorldContextObject"))
+	static void LeaveEOSRoom(const UObject* WorldContextObject, FString VoiceRoomName, const FEIKResultDelegate& Result);
 
     // Gets a list of players in the specified voice room.
-	UFUNCTION(BlueprintCallable, DisplayName="Get Players in EOS Voice Room", Category="EVIK")
-	static TArray<FString> GetPlayersInRoom(APlayerController* PlayerController, FString VoiceRoomName);
+	UFUNCTION(BlueprintCallable, DisplayName="Get Players in EOS Voice Room", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+	static TArray<FString> GetPlayersInRoom(const UObject* WorldContextObject, FString VoiceRoomName);
 
     // Gets a list of all joined voice rooms.
-	UFUNCTION(BlueprintCallable, DisplayName="Get Joined EOS Voice Rooms", Category="EVIK")
-	static TArray<FString> GetAllRooms(APlayerController* PlayerController);
+	UFUNCTION(BlueprintCallable, DisplayName="Get Joined EOS Voice Rooms", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+	static TArray<FString> GetAllRooms(const UObject* WorldContextObject);
 
     // Gets the volume for the specified player.
-	UFUNCTION(BlueprintPure, DisplayName="Get EOS Voice Player Volume", Category="EVIK")
-	static float GetPlayerVolume(const APlayerController* PlayerController, const FString& PlayerName);
+	UFUNCTION(BlueprintPure, DisplayName="Get EOS Voice Player Volume", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+	static float GetPlayerVolume(const UObject* WorldContextObject, const FString& PlayerName);
 
 	//UFUNCTION(BlueprintPure, DisplayName="Get EOS Voice ProductUserID", Category="EVIK")
 	static char* GetProductUserID(const FString& PlayerName);
 	
     // Sets the volume for the specified player.
-	UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Player Volume", Category="EVIK")
-	static bool SetPlayerVolume(const APlayerController* PlayerController, const FString& PlayerName, float NewVolume);
+	UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Player Volume", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+	static bool SetPlayerVolume(const UObject* WorldContextObject, const FString& PlayerName, float NewVolume);
 
 	    // Checks if the specified player is muted in EOS Voice Chat.
-    UFUNCTION(BlueprintPure, DisplayName="Is EOS Voice Player Muted", Category="EVIK")
-    static bool IsPlayerMuted(const APlayerController* PlayerController, const FString& PlayerName);
+    UFUNCTION(BlueprintPure, DisplayName="Is EOS Voice Player Muted", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static bool IsPlayerMuted(const UObject* WorldContextObject, const FString& PlayerName);
 
     // Sets the specified player's mute status in EOS Voice Chat.
-    UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Player Muted", Category="EVIK")
-    static bool SetPlayerMuted(const APlayerController* PlayerController, const FString& PlayerName, bool MutePlayer);
+    UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Player Muted", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static bool SetPlayerMuted(const UObject* WorldContextObject, const FString& PlayerName, bool MutePlayer);
 
     // Transmits the player's voice to all joined EOS Voice Rooms.
-    UFUNCTION(BlueprintCallable, DisplayName="Transmit Voice To All EOS Voice Rooms", Category="EVIK")
-    static bool TransmitToAllRooms(const APlayerController* PlayerController);
+    UFUNCTION(BlueprintCallable, DisplayName="Transmit Voice To All EOS Voice Rooms", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static bool TransmitToAllRooms(const UObject* WorldContextObject);
 
     // Transmits the player's voice to a selected EOS Voice Room.
-    UFUNCTION(BlueprintCallable, DisplayName="Transmit Voice To Selected EOS Voice Room", Category="EVIK")
-    static bool TransmitToSelectedRoom(const APlayerController* PlayerController, FString RoomName);
+    UFUNCTION(BlueprintCallable, DisplayName="Transmit Voice To Selected EOS Voice Room", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static bool TransmitToSelectedRoom(const UObject* WorldContextObject, FString RoomName);
 
     // Stops transmitting the player's voice to any EOS Voice Room.
-    UFUNCTION(BlueprintCallable, DisplayName="Transmit Voice To No EOS Voice Room", Category="EVIK")
-    static bool TransmitToNoRoom(const APlayerController* PlayerController);
+    UFUNCTION(BlueprintCallable, DisplayName="Transmit Voice To No EOS Voice Room", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static bool TransmitToNoRoom(const UObject* WorldContextObject);
 
     // Retrieves all available input methods for EOS Voice Chat.
-    UFUNCTION(BlueprintCallable, DisplayName="Get All EOS Voice Input Methods", Category="EVIK")
-    static TArray<FDeviceEVIKSettings> GetInputMethods(const APlayerController* PlayerController);
+    UFUNCTION(BlueprintCallable, DisplayName="Get All EOS Voice Input Methods", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static TArray<FDeviceEVIKSettings> GetInputMethods(const UObject* WorldContextObject);
 
     // Retrieves all available output methods for EOS Voice Chat.
-    UFUNCTION(BlueprintCallable, DisplayName="Get All EOS Voice Output Methods", Category="EVIK")
-    static TArray<FDeviceEVIKSettings> GetOutputMethods(const APlayerController* PlayerController);
+    UFUNCTION(BlueprintCallable, DisplayName="Get All EOS Voice Output Methods", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static TArray<FDeviceEVIKSettings> GetOutputMethods(const UObject* WorldContextObject);
 
     // Sets the EOS Voice Chat output method based on the provided method ID.
-    UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Output Method", Category="EVIK")
-    static bool SetOutputMethods(const APlayerController* PlayerController, FString MethodID);
+    UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Output Method", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static bool SetOutputMethods(const UObject* WorldContextObject, FString MethodID);
 
     // Sets the EOS Voice Chat input method based on the provided method ID.
-    UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Output Method", Category="EVIK")
-    static bool SetInputMethods(const APlayerController* PlayerController, FString MethodID);
+    UFUNCTION(BlueprintCallable, DisplayName="Set EOS Voice Output Method", Category="EVIK", meta=(WorldContext="WorldContextObject"))
+    static bool SetInputMethods(const UObject* WorldContextObject, FString MethodID);
 
 	
 };


### PR DESCRIPTION
I started to research how to implement voice chat in my project, which is solely a client / dedicated server approach. The EIKVoiceChat nodes seem to require a PlayerController reference, but as far as I've understood, the `EOSRoomToken` node should be run on the server (in my case dedicated server) in order to create a voice chat room. According to my knowledge, there are no instances of `PlayerController` on dedicated servers, which would make `EOSRoomToken` node unusable as there would be no `PlayerController` to pass in.

I noticed the `PlayerController` parameters are only used to reference the game instance behind the scenes. This PR suggests a different approach is used to reference the game instance, which removes the necessity to input a `PlayerController` object.

Please feel free to reject this PR if you think it's not a good suggestion... I haven't even made the voice chat work in my project yet, but the code seems to compile with these changes. I can now continue my research.

Before:
![Screenshot_52](https://github.com/betidestudio/EOSIntegrationKit/assets/11492515/0dbf60de-1698-4ed8-a1dd-ec333735bd51)

After:
![Screenshot_54](https://github.com/betidestudio/EOSIntegrationKit/assets/11492515/429ecb5a-0d01-47ce-abb5-a3450ccaad2b)
