### PR TITLE
fix: Replace _NODISCARD with [[nodiscard]] to fix Linux compilation (…

### DIFF
--- a/Source/OnlineSubsystemEIK/Private/OnlineSubsystemEOSTypes.h
+++ b/Source/OnlineSubsystemEIK/Private/OnlineSubsystemEOSTypes.h
@@ -398,7 +398,7 @@ namespace OSSInternalCallback
 	/** Create a callback for a non-SDK function that is tied to the lifetime of an arbitrary shared pointer. */
 	template <typename DelegateType, typename OwnerType, typename... CallbackArgs>
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >3
-	_NODISCARD DelegateType Create(const TSharedPtr<OwnerType, ESPMode::ThreadSafe>& InOwner,
+	[[nodiscard]] DelegateType Create(const TSharedPtr<OwnerType, ESPMode::ThreadSafe>& InOwner,
 #else
 	UE_NODISCARD DelegateType Create(const TSharedPtr<OwnerType, ESPMode::ThreadSafe>& InOwner,
 #endif


### PR DESCRIPTION
The _NODISCARD macro was causing compilation errors on the Linux platform.

Replacing it with the standard [[nodiscard]] attribute resolves the issue.

Inspired by:
https://github.com/EpicGames/UnrealEngine/commit/7da84c1d1bc6259b9aaaa21afe9f5549e8135d61