### PR TITLE
Wrap GetStringField/GetIntegerField with TEXT() to prevent warning

### DIFF
--- a/Source/OnlineSubsystemEIK/AsyncFunctions/SupportTickets/EIK_ExportTicketUserData_Async.cpp
+++ b/Source/OnlineSubsystemEIK/AsyncFunctions/SupportTickets/EIK_ExportTicketUserData_Async.cpp
@@ -77,7 +77,7 @@ void UEIK_ExportTicketUserData_Async::OnResponseReceived(FHttpRequestPtr Request
 
         if (FJsonSerializer::Deserialize(Reader, JsonObject))
         {
-            TArray<TSharedPtr<FJsonValue>> DataArray = JsonObject->GetArrayField("data");
+            TArray<TSharedPtr<FJsonValue>> DataArray = JsonObject->GetArrayField(TEXT("data"));
 
             TArray<FConversationData> Conversations;
 
@@ -88,25 +88,25 @@ void UEIK_ExportTicketUserData_Async::OnResponseReceived(FHttpRequestPtr Request
                 FConversationData ConversationData;
 
                 // Fill the ConversationData structure with the parsed data
-                ConversationData.Guid = DataObject->GetStringField("guid");
-                ConversationData.Subject = DataObject->GetStringField("subject");
-                ConversationData.Message = DataObject->GetStringField("message");
-                ConversationData.SenderName = DataObject->GetStringField("sender_name");
-                ConversationData.SenderEmail = DataObject->GetStringField("sender_email");
-                ConversationData.Timestamp = DataObject->GetStringField("timestamp");
+                ConversationData.Guid = DataObject->GetStringField(TEXT("guid"));
+                ConversationData.Subject = DataObject->GetStringField(TEXT("subject"));
+                ConversationData.Message = DataObject->GetStringField(TEXT("message"));
+                ConversationData.SenderName = DataObject->GetStringField(TEXT("sender_name"));
+                ConversationData.SenderEmail = DataObject->GetStringField(TEXT("sender_email"));
+                ConversationData.Timestamp = DataObject->GetStringField(TEXT("timestamp"));
 
                 // Parse the "messages" array
-                TArray<TSharedPtr<FJsonValue>> MessagesArray = DataObject->GetArrayField("messages");
+                TArray<TSharedPtr<FJsonValue>> MessagesArray = DataObject->GetArrayField(TEXT("messages"));
                 for (int32 j = 0; j < MessagesArray.Num(); j++)
                 {
                     TSharedPtr<FJsonObject> MessageObject = MessagesArray[j]->AsObject();
 
                     FMessageData Message;
-                    Message.TicketId = MessageObject->GetIntegerField("ticket_id");
-                    Message.Message = MessageObject->GetStringField("message");
-                    Message.SenderName = MessageObject->GetStringField("sender_name");
-                    Message.SenderEmail = MessageObject->GetStringField("sender_email");
-                    Message.Timestamp = MessageObject->GetStringField("timestamp");
+                    Message.TicketId = MessageObject->GetIntegerField(TEXT("ticket_id"));
+                    Message.Message = MessageObject->GetStringField(TEXT("message"));
+                    Message.SenderName = MessageObject->GetStringField(TEXT("sender_name"));
+                    Message.SenderEmail = MessageObject->GetStringField(TEXT("sender_email"));
+                    Message.Timestamp = MessageObject->GetStringField(TEXT("timestamp"));
 
                     ConversationData.Messages.Add(Message);
                 }

--- a/Source/OnlineSubsystemEIK/AsyncFunctions/SupportTickets/EIK_SendSupportTicket_Async.cpp
+++ b/Source/OnlineSubsystemEIK/AsyncFunctions/SupportTickets/EIK_SendSupportTicket_Async.cpp
@@ -111,22 +111,22 @@ void UEIK_SendSupportTicket_Async::OnResponseReceived(FHttpRequestPtr Request, F
         if (FJsonSerializer::Deserialize(Reader, JsonObject))
         {
             // Get the 'data' object
-            TSharedPtr<FJsonObject> DataObject = JsonObject->GetObjectField("data");
+            TSharedPtr<FJsonObject> DataObject = JsonObject->GetObjectField(TEXT("data"));
 
-            // Populate the struct
+             // Populate the struct
             FSupportTicketResponseData ResponseData;
-            ResponseData.prod_name = DataObject->GetStringField("prod_name");
-            ResponseData.prod_slug = DataObject->GetStringField("prod_slug");
-            ResponseData.guid = DataObject->GetStringField("guid");
-            ResponseData.sender_name = DataObject->GetStringField("sender_name");
-            ResponseData.sender_email = DataObject->GetStringField("sender_email");
-            ResponseData.subject = DataObject->GetStringField("subject");
-            ResponseData.message = DataObject->GetStringField("message");
-            ResponseData.error_code = DataObject->GetStringField("error_code");
-            ResponseData.system_os = DataObject->GetStringField("system_os");
-            ResponseData.system_antimalware = DataObject->GetStringField("system_antimalware");
-            ResponseData.system_other = DataObject->GetStringField("system_other");
-            ResponseData.timestamp = DataObject->GetStringField("timestamp");
+            ResponseData.prod_name = DataObject->GetStringField(TEXT("prod_name"));
+            ResponseData.prod_slug = DataObject->GetStringField(TEXT("prod_slug"));
+            ResponseData.guid = DataObject->GetStringField(TEXT("guid"));
+            ResponseData.sender_name = DataObject->GetStringField(TEXT("sender_name"));
+            ResponseData.sender_email = DataObject->GetStringField(TEXT("sender_email"));
+            ResponseData.subject = DataObject->GetStringField(TEXT("subject"));
+            ResponseData.message = DataObject->GetStringField(TEXT("message"));
+            ResponseData.error_code = DataObject->GetStringField(TEXT("error_code"));
+            ResponseData.system_os = DataObject->GetStringField(TEXT("system_os"));
+            ResponseData.system_antimalware = DataObject->GetStringField(TEXT("system_antimalware"));
+            ResponseData.system_other = DataObject->GetStringField(TEXT("system_other"));
+            ResponseData.timestamp = DataObject->GetStringField(TEXT("timestamp"));
 
             // Broadcast the success delegate
             Success.Broadcast(Response->GetContentAsString(), ResponseData, Response->GetResponseCode());


### PR DESCRIPTION
 Passing an ANSI string to GetStringField has been deprecated outside of UTF-8 mode