### PR TITLE
Fixed plugin compilation errors on Linux against UE 5.4

### DIFF
--- a/Source/EOSIntegrationKit/Private/EIKSettings.cpp
+++ b/Source/EOSIntegrationKit/Private/EIKSettings.cpp
@@ -11,6 +11,7 @@
 
 #if WITH_EDITOR
 	#include "Misc/MessageDialog.h"
+	#include "UnrealEdMisc.h"
 #endif
 
 #define LOCTEXT_NAMESPACE "EOS"

--- a/Source/OnlineSubsystemEIK/Private/EIK_EngineSubsystem.cpp
+++ b/Source/OnlineSubsystemEIK/Private/EIK_EngineSubsystem.cpp
@@ -8,6 +8,10 @@
 #include "OnlineSubsystem.h"
 #include "Interfaces/OnlineIdentityInterface.h"
 
+#if WITH_EDITOR
+	#include "Editor.h"
+#endif
+
 void UEIK_EngineSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 #if WITH_EDITOR

--- a/Source/OnlineSubsystemEIK/Private/OnlineSubsystemModuleEIK.cpp
+++ b/Source/OnlineSubsystemEIK/Private/OnlineSubsystemModuleEIK.cpp
@@ -22,6 +22,7 @@
 #if WITH_EDITOR
 	#include "ISettingsModule.h"
 	#include "ISettingsSection.h"
+	#include "ToolMenus.h"
 #endif
 
 #define LOCTEXT_NAMESPACE "EIK"


### PR DESCRIPTION
EIK was not able to compile on linux, due to missing headers. Probably because of toolchain differences between the platforms.
It is still compiling fine on windows with these changes.

Build was done on Arch Linux against epic's distributed UE version of 5.4.1