### PR TITLE
Fix DeviceId 60 Minute Refresh

### DIFF
--- a/Source/OnlineSubsystemEIK/Private/UserManagerEOS.cpp
+++ b/Source/OnlineSubsystemEIK/Private/UserManagerEOS.cpp
@@ -1274,7 +1274,9 @@ void FUserManagerEOS::RefreshConnectLogin(int32 LocalUserNum)
 		return;
 	}
 
-	if(LocalUserNumToLastLoginCredentials[0]->Type == TEXT("deviceid"))
+	UE_LOG(LogTemp, Log, TEXT("RefreshConnectLogin(%d) for credential type %s"), LocalUserNum, *LocalUserNumToLastLoginCredentials[0]->Type);
+
+	if(LocalUserNumToLastLoginCredentials[0]->Type.Contains(TEXT("DEVICEID"), ESearchCase::IgnoreCase))
 	{
 		UE_LOG(LogTemp, Warning, TEXT("Refresh Connect Login for Device ID"));
 		LoginViaConnectInterface(*LocalUserNumToLastLoginCredentials[0]);


### PR DESCRIPTION
We were having an issue where when were logging in via device id, it wasn't refreshing automatically after 60 minutes.

After some troubleshooting, we discovered the issue was that the last login credentials type was actually "noeas_+_EIK_ECT_DEVICEID_ACCESS_TOKEN" instead of "deviceid". Not sure when, or if, it would ever be just "deviceid", so tried to implement this in a way that would accommodate both. None of the other login types have the text "deviceid" in them, so it should be safe.