### PR TITLE
Avoid Crash when no/valid PlayerController is passed.

### DIFF
--- a/Source/OnlineSubsystemEIK/AsyncFunctions/Extra/EIK_BlueprintFunctions.cpp
+++ b/Source/OnlineSubsystemEIK/AsyncFunctions/Extra/EIK_BlueprintFunctions.cpp
@@ -666,6 +666,12 @@ TArray<uint8> UEIK_BlueprintFunctions::StringToByteArray(const FString& DataToCo
 
 FEIKUniqueNetId UEIK_BlueprintFunctions::GetUserUniqueID(const APlayerController* PlayerController, bool& bIsValid)
 {
+	// ROSE CHANGE BEGIN: Avoid Crashes when no/no valid PlayerController is passed
+	if(!PlayerController)
+	{
+		return FEIKUniqueNetId();
+	}
+	// ROSE CHANGE END
 	if(const APlayerState* PlayerState = PlayerController->PlayerState; !PlayerState)
 	{
 		bIsValid = false;

--- a/Source/OnlineSubsystemEIK/AsyncFunctions/Extra/EIK_BlueprintFunctions.cpp
+++ b/Source/OnlineSubsystemEIK/AsyncFunctions/Extra/EIK_BlueprintFunctions.cpp
@@ -669,6 +669,7 @@ FEIKUniqueNetId UEIK_BlueprintFunctions::GetUserUniqueID(const APlayerController
 	// ROSE CHANGE BEGIN: Avoid Crashes when no/no valid PlayerController is passed
 	if(!PlayerController)
 	{
+		bIsValid = false;
 		return FEIKUniqueNetId();
 	}
 	// ROSE CHANGE END


### PR DESCRIPTION
The Code made the Game crash when no (valid) PlayerController was passed when getting the Users Unique ID. I fixed it by checking the PlayerController. (EIK_BlueprintFunctions.cpp)
This is probably a issue with other functions too. Thanks