### PR TITLE
fix: multi VoiceChatSynth Components support & log config

### DIFF
--- a/Source/EIKVoiceChat/Private/EOSVoiceChatUser.cpp
+++ b/Source/EIKVoiceChat/Private/EOSVoiceChatUser.cpp
@@ -2469,6 +2469,7 @@ void FEOSVoiceChatUser::OnChannelAudioBeforeRender(const EOS_RTCAudio_AudioBefor
 						SpeakerActor->GetComponents<UEIKVoiceChatSynthComponent>(VoiceChatSynthComponents);
 						if(VoiceChatSynthComponents.Num() > 0)
 						{
+							bool bFoundValidVoiceChatSynthComponent = false;
 							for(auto VoiceChatSynthComponent : VoiceChatSynthComponents)
 							{
 								if (IsValid(VoiceChatSynthComponent))

--- a/Source/EIKVoiceChat/Private/EOSVoiceChatUser.cpp
+++ b/Source/EIKVoiceChat/Private/EOSVoiceChatUser.cpp
@@ -2471,28 +2471,27 @@ void FEOSVoiceChatUser::OnChannelAudioBeforeRender(const EOS_RTCAudio_AudioBefor
 						{
 							for(auto VoiceChatSynthComponent : VoiceChatSynthComponents)
 							{
-								if (IsValid(VoiceChatSynthComponent) && (VoiceChatSynthComponent->SupportedRooms.Contains(ChannelName) || VoiceChatSynthComponent->bUseGlobalRoom))
+								if (IsValid(VoiceChatSynthComponent))
 								{
-									if (VoiceChatSynthComponent->IsActive())
+									if(VoiceChatSynthComponent->SupportedRooms.Contains(ChannelName) || VoiceChatSynthComponent->bUseGlobalRoom)
 									{
-										VoiceChatSynthComponent->WriteSamples(Samples);
-										//if we're here, it means that we passed audio to all valid components, so we need to clear the buffer so that it isn't played by the RTC.
-										FMemory::Memset(Samples.GetData(), 0, Samples.Num() * sizeof(int16));
+										if (VoiceChatSynthComponent->IsActive())
+										{
+											VoiceChatSynthComponent->WriteSamples(Samples);
+											bFoundValidVoiceChatSynthComponent = true;
+										}
 									}
-									else
-									{
-										UE_LOG(LogTemp,Warning,TEXT("VoiceChatSynthComponent is not active"));
-									}
-								}
-								else
-								{
-									UE_LOG(LogTemp,Warning,TEXT("VoiceChatSynthComponent is not valid"));
 								}
 							}
-						}
-						else
+							if (!bFoundValidVoiceChatSynthComponent)
+							{
+								UE_LOG(LogEOSVoiceChat,Warning,TEXT("no valid or active VoiceChatSynthComponent found"));
+							}
+							//if we're here, it means that we passed audio to all valid components, so we need to clear the buffer so that it isn't played by the RTC.
+							FMemory::Memset(Samples.GetData(), 0, Samples.Num() * sizeof(int16));
+						}else
 						{
-							UE_LOG(LogTemp,Warning,TEXT("VoiceChatSynthComponent is not found"));
+							UE_LOG(LogEOSVoiceChat,Warning,TEXT("no VoiceChatSynthComponent found"));
 						}
 					}
 				}
@@ -2508,7 +2507,7 @@ void FEOSVoiceChatUser::OnChannelAudioBeforeRender(const EOS_RTCAudio_AudioBefor
 		}
 		else
 		{
-			UE_LOG(LogTemp,Warning,TEXT("GEngine is not found"));
+			UE_LOG(LogEOSVoiceChat,Warning,TEXT("GEngine is not found"));
 		}
 	}
 }

--- a/Source/EIKVoiceChat/Private/EOSVoiceChatUser.cpp
+++ b/Source/EIKVoiceChat/Private/EOSVoiceChatUser.cpp
@@ -2490,7 +2490,8 @@ void FEOSVoiceChatUser::OnChannelAudioBeforeRender(const EOS_RTCAudio_AudioBefor
 							}
 							//if we're here, it means that we passed audio to all valid components, so we need to clear the buffer so that it isn't played by the RTC.
 							FMemory::Memset(Samples.GetData(), 0, Samples.Num() * sizeof(int16));
-						}else
+						}
+						else
 						{
 							UE_LOG(LogEOSVoiceChat,Warning,TEXT("no VoiceChatSynthComponent found"));
 						}


### PR DESCRIPTION
- fix a log spamming issue when configuring more than one VoiceChatSynth Component
- fix the logging config: `UE_LOG(LogTemp,Warning,TEXT("VoiceChatSynthComponent is not active"))` -> `UE_LOG(LogEOSVoiceChat,VeryVerbose,TEXT("VoiceChatSynthComponent is not active"));`
- better handling multiple VoiceChatSynth Components by clearing the buffer only after it actually passed audio to all valid components

It has been tested in standalone mode & packaged build