### PR TITLE
Fixing web auth on steam to use new expected token type

### DIFF
--- a/Source/OnlineSubsystemEIK/Private/UserManagerEOS.cpp
+++ b/Source/OnlineSubsystemEIK/Private/UserManagerEOS.cpp
@@ -304,7 +304,7 @@ void FUserManagerEOS::GetPlatformAuthToken(int32 LocalUserNum, const FOnGetLinke
 	// TODO config map of OSS -> token type?
 	if (PlatformOSS->GetSubsystemName() == STEAM_SUBSYSTEM)
 	{
-		TokenType = TEXT("Session");
+		TokenType = TEXT("WebAPI:epiconlineservices");
 	}
 
 	// Request the auth token from the platform


### PR DESCRIPTION
I noticed when I was playing around with Steam auth that EOS is expecting steam webtokens to be formatted slightly differently. Since epic now want to provide RemoteServiceIdentity=epiconlineservices you can add this using the this syntax. See FOnlineIdentitySteam::GetLinkedAccountAuthToken for implementation.